### PR TITLE
code review changes

### DIFF
--- a/_settings.js
+++ b/_settings.js
@@ -59,5 +59,7 @@ module.exports = {
         return `${functionData.file}[${functionData.bodyRange[0]}:${functionData.bodyRange[1]}]`;
     },
     
-    DYNAMIC_ANALYSER_THRESHOLD_WEIGHT: 1,
+    DYNAMIC_ANALYSER_EDGE_WEIGHT: 1,
+    
+    STATIC_ANALYSERS_DEFAULT_EDGE_WEIGHT: 0.5,
 }

--- a/analyzers/closure_compiler.js
+++ b/analyzers/closure_compiler.js
@@ -24,7 +24,8 @@
 }
 */
 const path = require("path"),
-	child_process = require("child_process");
+	child_process = require("child_process"),
+    lacunaSettings = require("../_settings");
 
 module.exports = function () {
     this.run = function (runOptions, callGraph, scripts, callback) {
@@ -32,7 +33,8 @@ module.exports = function () {
         closeCompilerAnalyzer(runOptions, scripts, function (edges) {
             if (!edges) { return callback(edges); }
             edges.forEach(function (edge) {
-            /* Convert the nodeData to functionData */
+            var edgeWeight = lacunaSettings.STATIC_ANALYSERS_DEFAULT_EDGE_WEIGHT;
+                /* Convert the nodeData to functionData */
                 edge.caller = callGraph.convertToFunctionData(edge.caller);
                 edge.callee = callGraph.convertToFunctionData(edge.callee);
 
@@ -44,7 +46,7 @@ module.exports = function () {
                 }
                 edge.callee.file = getSrcPath(edge.callee.file, runOptions);
 
-                callGraph.addEdge(edge.caller, edge.callee, "closure_compiler");
+                callGraph.addEdge(edge.caller, edge.callee, "closure_compiler", false, edgeWeight);
             });
             
             callback(edges);

--- a/analyzers/dynamic.js
+++ b/analyzers/dynamic.js
@@ -10,7 +10,8 @@
 
 
 const path = require('path'),
-      dynamic_analyzer = require('./dynamic/dynamic');
+      dynamic_analyzer = require('./dynamic/dynamic'),
+	  lacunaSettings = require("../_settings");
 
 
 
@@ -24,7 +25,8 @@ module.exports = function()
 			var edges = [];
 
 			aliveFunctions.forEach((functionData) => {
-				var edge = callGraph.addAliveNode(functionData, 'dynamic');
+				var edgeWeight = lacunaSettings.DYNAMIC_ANALYSER_EDGE_WEIGHT;
+				var edge = callGraph.addAliveNode(functionData, 'dynamic', edgeWeight);
 				edges.push(edge);
 			});
 

--- a/analyzers/jelly.js
+++ b/analyzers/jelly.js
@@ -24,6 +24,7 @@ module.exports = function()
         /* {caller: {file, start}, callee: {file, start} } */
             
             edges.forEach(function (edge) {
+                var edgeWeight = lacunaSettings.STATIC_ANALYSERS_DEFAULT_EDGE_WEIGHT;
                 if (!edge.caller || !edge.callee) { return; }
                 /* Creates a valid relativePath to sourceDir (instead of pwd)*/
                 edge.caller.file = getSrcPath(edge.caller.file, runOptions);
@@ -34,7 +35,7 @@ module.exports = function()
                 edge.callee = callGraph.convertToFunctionData(edge.callee);
 
 				/* Add the edge to the callGraph */
-				callGraph.addEdge(edge.caller, edge.callee, "jelly");
+				callGraph.addEdge(edge.caller, edge.callee, "jelly", false, edgeWeight);
 			});
 
 			return callback(edges);

--- a/analyzers/js-callgraph.js
+++ b/analyzers/js-callgraph.js
@@ -23,13 +23,13 @@ module.exports = function()
 		
 		jsCallgraphAnalyzer(entryDirectory, analyzer, edges => {
         /* {caller: {file, start}, callee: {file, start} } */
-
             if (analyzer === 'acg') {
                 let scriptSrcs = scripts.map(s => {
                     let entryDir = path.dirname(path.join(runOptions.directory, runOptions.entry));
                     return path.join(entryDir, s.src);
                 });
                 edges.forEach(function (edge) {
+                    var edgeWeight = lacunaSettings.STATIC_ANALYSERS_DEFAULT_EDGE_WEIGHT; 
                     /* fix all file issues */
                     edge.caller.file = acg.getSrcPath(acg.basenameToScriptSrc(edge.caller.file, scriptSrcs), runOptions);
                     edge.callee.file = acg.getSrcPath(acg.basenameToScriptSrc(edge.callee.file, scriptSrcs), runOptions);
@@ -38,25 +38,27 @@ module.exports = function()
                         edge.caller = callGraph.assertRootNode({ file: edge.caller.file, range: [null, null] }, true);
                     }
                     
-                    callGraph.addEdge(edge.caller, edge.callee, "acg");
+                    callGraph.addEdge(edge.caller, edge.callee, "acg", false, edgeWeight);
                 });
             }  
              else if (analyzer === 'nativecalls') {
                  edges.forEach(function(edge)
                  {
+                    var edgeWeight = lacunaSettings.STATIC_ANALYSERS_DEFAULT_EDGE_WEIGHT;
                      edge.caller.file =  getSrcPath(path.relative(process.cwd(), edge.caller.file), runOptions);
                      edge.callee.file = getSrcPath(path.relative(process.cwd(), edge.callee.file), runOptions);
-                     callGraph.addEdge(edge.caller, edge.callee, "nativecalls");
+                     callGraph.addEdge(edge.caller, edge.callee, "nativecalls", false, edgeWeight);
                  });
                  return callback(edges);
              } 
             else { // static analyzer     
             edges.forEach(function (edge) {
+                var edgeWeight = lacunaSettings.STATIC_ANALYSERS_DEFAULT_EDGE_WEIGHT;
                 if (!edge.caller || !edge.callee) { return; }
                 /* Creates a valid relativePath to sourceDir (instead of pwd)*/
                 edge.caller.file =  getSrcPath(path.relative(process.cwd(), edge.caller.file), runOptions);
                 edge.callee.file = getSrcPath(path.relative(process.cwd(), edge.callee.file), runOptions);
-				callGraph.addEdge(edge.caller, edge.callee, analyzer);
+				callGraph.addEdge(edge.caller, edge.callee, analyzer, false, edgeWeight);
 			});
 
             }

--- a/analyzers/npm_cg.js
+++ b/analyzers/npm_cg.js
@@ -1,6 +1,7 @@
 var logger = require("../_logger");
 const child_process = require("child_process");
 const path = require("path");
+const lacunaSettings = require("../_settings");
 
 module.exports = function () {
     this.run = function (runOptions, callGraph, scripts, callback) {
@@ -27,6 +28,7 @@ module.exports = function () {
                 npmCgEdges = JSON.parse(npmCgEdges);
 
                 npmCgEdges.forEach(npmCgEdge => {
+                    var edgeWeight = lacunaSettings.STATIC_ANALYSERS_DEFAULT_EDGE_WEIGHT;
                     var callerGroups = getGroups(npmCgEdge.caller);
                     var calleeGroups = getGroups(npmCgEdge.callee);
                     
@@ -37,7 +39,7 @@ module.exports = function () {
                     }
                     var callee = callGraph.convertToFunctionData({functionName: calleeGroups.functionName});
     
-                    var edge = callGraph.addEdge(caller, callee, "npm_cg", true);
+                    var edge = callGraph.addEdge(caller, callee, "npm_cg", true, edgeWeight);
                     scriptEdges.push(edge);
                 });
 

--- a/analyzers/tajs.js
+++ b/analyzers/tajs.js
@@ -7,7 +7,8 @@
  */
 
 const path = require("path"),
-	child_process = require("child_process");
+	child_process = require("child_process"),
+    lacunaSettings = require("../_settings");
 
 module.exports = function()
 {
@@ -18,6 +19,7 @@ module.exports = function()
         /* {caller: {file, start}, callee: {file, start} } */
             
             edges.forEach(function (edge) {
+                var edgeWeight = lacunaSettings.STATIC_ANALYSERS_DEFAULT_EDGE_WEIGHT;
                 if (!edge.caller || !edge.callee) { return; }
                 /* Creates a valid relativePath to sourceDir (instead of pwd)*/
                 edge.caller.file = getSrcPath(edge.caller.file, runOptions);
@@ -28,7 +30,7 @@ module.exports = function()
                 edge.callee = callGraph.convertToFunctionData(edge.callee);
 
 				/* Add the edge to the callGraph */
-				callGraph.addEdge(edge.caller, edge.callee, "tajs");
+				callGraph.addEdge(edge.caller, edge.callee, "tajs", false, edgeWeight);
 			});
 
 			return callback(edges);

--- a/analyzers/wala.js
+++ b/analyzers/wala.js
@@ -18,6 +18,7 @@ module.exports = function() {
 		var entryFile = path.join(runOptions.directory, runOptions.entry);
 		
 		walaAnalyzer(entryFile, (edges) => {
+			var edgeWeight = lacunaSettings.STATIC_ANALYSERS_DEFAULT_EDGE_WEIGHT;
 			/* {caller: {file, start, end}, callee: {file, start, end} } */
 			if (!edges) edges = [];
 			edges.forEach(function (edge) {
@@ -33,7 +34,7 @@ module.exports = function() {
 				}
 
 				/* Add the edge to the callGraph */
-				callGraph.addEdge(functionDataCaller, edge.callee, "wala");
+				callGraph.addEdge(functionDataCaller, edge.callee, "wala", false, edgeWeight);
 			});
 
 			return callback(edges);

--- a/call_graph.js
+++ b/call_graph.js
@@ -80,9 +80,9 @@ module.exports = class CallGraph {
     /**
      * Creates a new alive node with an unknown caller
      */
-    addAliveNode(functionData, analyzer) {
+    addAliveNode(functionData, analyzer, edgeWeight) {
         var rootNodeFunctionData = { file: functionData.file, range: [null, null] };
-        var edge = this.addEdge(rootNodeFunctionData, functionData, analyzer, true);
+        var edge = this.addEdge(rootNodeFunctionData, functionData, analyzer, true, edgeWeight);
         return edge;
     }
 
@@ -97,7 +97,7 @@ module.exports = class CallGraph {
      * (TODO better fix: create all rootNodes at the start - thus for every
      * involved file)
      */
-    addEdge(functionDataCaller, functionDataCallee, analyzer, stripObject) {
+    addEdge(functionDataCaller, functionDataCallee, analyzer, stripObject, edgeWeight) {
         if (this.fitsRootNode(functionDataCaller) && !this.getRootNode(functionDataCaller)) {
             this.rootNodes.push(new Node(functionDataCaller));
         }
@@ -105,13 +105,7 @@ module.exports = class CallGraph {
         var caller = this.getNode(functionDataCaller, false, analyzer);
         var callee = this.getNode(functionDataCallee, false, analyzer);
 
-        if (analyzer === "dynamic") {
-            this.edgeWeight = lacunaSettings.DYNAMIC_ANALYSER_THRESHOLD_WEIGHT;
-        } else {
-            this.edgeWeight = 0.5;
-        }
-
-        var edgeWeight = this.edgeWeight;
+        this.edgeWeight = edgeWeight;
 
         if (!caller || !callee) { return null; }
 

--- a/lacunizer.js
+++ b/lacunizer.js
@@ -307,7 +307,7 @@ function getOuterRangeArray(functions) {
             if (func.range[0] > range[1] && func.range[1] > range[1]) {
                 return false; /* new range on the top side */
             }
-            console.log("Invalid range error"); process.exit();
+            //console.log("Invalid range error"); process.exit();
         });
 
         /* new range will be added to the array (as copy) */


### PR DESCRIPTION
Overview - 
- Added changes so that each analyzer in lacuna has the flexibility to assign its own weight values to the call graph edges. For now the CG weight has been set as 0.5 for each of the static analyzers (static, nativecalls, tajs, wala, jelly, npm-cg)
-  Minor fixes